### PR TITLE
Docs: Refresh `README.md`; add a NuGet-specific one

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <p align="center">
   <a style="text-decoration:none" href="https://github.com/itsWindows11/ThreadSharp/actions/workflows/nuget.yml">
     <img src="https://github.com/itsWindows11/ThreadSharp/actions/workflows/nuget.yml/badge.svg" alt="CI Status" /></a>
-  <a style="text-decoration:none" href="https://discord.com/channels/714581497222398064/913496895006072843">
-    <img src="https://img.shields.io/badge/discuss-on%20discord-5865F2" alt="Discord" /></a>
+  <!--<a style="text-decoration:none" href="https://discord.com/channels/714581497222398064/913496895006072843">
+    <img src="https://img.shields.io/badge/discuss-on%20discord-5865F2" alt="Discord" /></a>-->
   <a style="text-decoration:none" href="https://www.nuget.org/packages/ThreadSharp">
     <img src="https://img.shields.io/nuget/v/ThreadSharp" alt="Discord" /></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ git clone https://github.com/itsWindows11/ThreadSharp
 
 ## License
 
-Copyright (c) 2024 `itsWindows11` & `ThreadSharp` contributors.
+Copyright (c) 2024 itsWindows11 & ThreadSharp contributors.
 
 Licensed under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Documentation
 
-You can browse the documentation at https://itswindows11.github.io/ThreadSharp.
+You can browse the documentation at [itswindows11.github.io/ThreadSharp](https://itswindows11.github.io/ThreadSharp/docs/).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ git clone https://github.com/itsWindows11/ThreadSharp
 ### Build the project
 
 - Open `ThreadSharp.sln`.
-- Set the Startup Project to `ThreadSharp.csproj` (of course!)
-- Build with `DEBUG` mode activated
+- Build `ThreadSharp.csproj` with `DEBUG` mode activated
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]
-> ThreadSharp is limited by the capabilities of the [Threads public API](https://developers.facebook.com/docs/threads/) and so not all features that you enjoy in the Threads app are available.
-
 ![ThreadSharp banner](https://github.com/itsWindows11/ThreadSharp/blob/main/assets/banner.png?raw=true)
 <h4 align="center"> A C# API wrapper for the Threads API.</h4>
 <p align="center">
@@ -11,6 +8,9 @@
   <a style="text-decoration:none" href="https://www.nuget.org/packages/ThreadSharp">
     <img src="https://img.shields.io/nuget/v/ThreadSharp" alt="Discord" /></a>
 </p>
+
+> [!IMPORTANT]
+> ThreadSharp is limited by the capabilities of the [Threads public API](https://developers.facebook.com/docs/threads/) and so not all features that you enjoy in the Threads app are available.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ There are multiple ways to participate in the community:
 
 ## Usage
 
-> [!NOTE]
-> ThreadSharp doesn't handle authentication manually, so you will have to handle the authentication depending on your platform's OAuth2 library.
-
 You can start by initializing a `ThreadsClient` with an access token:
 
 ```c#
 ThreadsClient threadsClient = new ThreadsClient("access-token");
 ```
+
+> [!NOTE]
+> ThreadSharp doesn't handle authentication manually, so you will have to handle the authentication depending on your platform's OAuth2 library.
 
 ## Building the Code
 

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ git clone https://github.com/itsWindows11/ThreadSharp
 
 Copyright (c) 2024 `itsWindows11` & `ThreadSharp` contributors.
 
-Licensed under the MIT license as stated in the [LICENSE](LICENSE).
+Licensed under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ ThreadsClient threadsClient = new ThreadsClient("access-token");
 Ensure you have following components:
 
 - [Git](https://git-scm.com/)
-- a .NET IDE of your choice, preferably [Visual Studio 2022](https://visualstudio.microsoft.com/vs/)
-- the .NET SDK
+- A .NET IDE of your choice, preferably [Visual Studio 2022](https://visualstudio.microsoft.com/vs/)
+- [The .NET SDK](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks)
 
 ### Git
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can browse the documentation at [itswindows11.github.io/ThreadSharp](https:/
 
 There are multiple ways to participate in the community:
 
-- Upvote popular feature requests
+- Upvote popular feature requests.
 - [Submit a new feature](https://github.com/itsWindows11/ThreadSharp/pulls)
 - [File bugs and feature requests](https://github.com/itsWindows11/ThreadSharp/issues/new/choose).
 - Review source [code changes](https://github.com/itsWindows11/ThreadSharp/commits)

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ You can browse the documentation at [itswindows11.github.io/ThreadSharp](https:/
 There are multiple ways to participate in the community:
 
 - Upvote popular feature requests.
-- [Submit a new feature](https://github.com/itsWindows11/ThreadSharp/pulls)
+- [Submit a new feature](https://github.com/itsWindows11/ThreadSharp/pulls).
 - [File bugs and feature requests](https://github.com/itsWindows11/ThreadSharp/issues/new/choose).
-- Review source [code changes](https://github.com/itsWindows11/ThreadSharp/commits)
+- Review [source code changes](https://github.com/itsWindows11/ThreadSharp/commits).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,34 @@
+> [!IMPORTANT]
+> ThreadSharp is limited by the capabilities of the [Threads public API](https://developers.facebook.com/docs/threads/) and so not all features that you enjoy in the Threads app are available.
+
 ![ThreadSharp banner](https://github.com/itsWindows11/ThreadSharp/blob/main/assets/banner.png?raw=true)
-
-# <center>ThreadSharp</center>
-<center>A C# API wrapper for the Threads API.</center>
-
-![NuGet Version](https://img.shields.io/nuget/v/ThreadSharp)
+<h4 align="center"> A C# API wrapper for the Threads API.</h4>
+<p align="center">
+  <a style="text-decoration:none" href="https://github.com/itsWindows11/ThreadSharp/actions/workflows/nuget.yml">
+    <img src="https://github.com/itsWindows11/ThreadSharp/actions/workflows/nuget.yml/badge.svg" alt="CI Status" /></a>
+  <a style="text-decoration:none" href="https://discord.com/channels/714581497222398064/913496895006072843">
+    <img src="https://img.shields.io/badge/discuss-on%20discord-5865F2" alt="Discord" /></a>
+  <a style="text-decoration:none" href="https://www.nuget.org/packages/ThreadSharp">
+    <img src="https://img.shields.io/nuget/v/ThreadSharp" alt="Discord" /></a>
+</p>
 
 ## Documentation
 
 You can browse the documentation at [itswindows11.github.io/ThreadSharp](https://itswindows11.github.io/ThreadSharp/docs/).
 
+## Contributing
+
+There are multiple ways to participate in the community:
+
+- Upvote popular feature requests
+- [Submit a new feature](https://github.com/itsWindows11/ThreadSharp/pulls)
+- [File bugs and feature requests](https://github.com/itsWindows11/ThreadSharp/issues/new/choose).
+- Review source [code changes](https://github.com/itsWindows11/ThreadSharp/commits)
+
 ## Usage
+
+> [!NOTE]
+> ThreadSharp doesn't handle authentication manually, so you will have to handle the authentication depending on your platform's OAuth2 library.
 
 You can start by initializing a `ThreadsClient` with an access token:
 
@@ -17,4 +36,32 @@ You can start by initializing a `ThreadsClient` with an access token:
 ThreadsClient threadsClient = new ThreadsClient("access-token");
 ```
 
-Note that ThreadSharp doesn't handle authentication manually, so you will have to handle the authentication depending on your platform's OAuth2 library.
+## Building the Code
+
+### Prerequisites
+
+Ensure you have following components:
+
+- [Git](https://git-scm.com/)
+- a .NET IDE of your choice, preferably [Visual Studio 2022](https://visualstudio.microsoft.com/vs/)
+- the .NET SDK
+
+### Git
+
+Clone the repository:
+
+```git
+git clone https://github.com/itsWindows11/ThreadSharp
+```
+
+### Build the project
+
+- Open `ThreadSharp.sln`.
+- Set the Startup Project to `ThreadSharp.csproj` (of course!)
+- Build with `DEBUG` mode activated
+
+## License
+
+Copyright (c) 2024 `itsWindows11` & `ThreadSharp` contributors.
+
+Licensed under the MIT license as stated in the [LICENSE](LICENSE).

--- a/src/README.md
+++ b/src/README.md
@@ -37,6 +37,6 @@ git clone https://github.com/itsWindows11/ThreadSharp
 
 ## License
 
-Copyright (c) 2024 `itsWindows11` & `ThreadSharp` contributors.
+Copyright (c) 2024 itsWindows11 & ThreadSharp contributors.
 
 Licensed under the [MIT License](https://github.com/itsWindows11/ThreadSharp/blob/main/LICENSE).

--- a/src/README.md
+++ b/src/README.md
@@ -33,8 +33,7 @@ git clone https://github.com/itsWindows11/ThreadSharp
 ### Build the project
 
 - Open `ThreadSharp.sln`.
-- Set the Startup Project to `ThreadSharp.csproj` (of course!)
-- Build with `DEBUG` mode activated
+- Build `ThreadSharp.csproj` with `DEBUG` mode activated
 
 ## License
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,43 @@
+![ThreadSharp banner](https://github.com/itsWindows11/ThreadSharp/blob/main/assets/banner.png?raw=true)
+
+## Documentation
+
+You can browse the documentation at [itswindows11.github.io/ThreadSharp](https://itswindows11.github.io/ThreadSharp/docs/).
+
+## Usage
+
+You can start by initializing a `ThreadsClient` with an access token:
+
+```c#
+ThreadsClient threadsClient = new ThreadsClient("access-token");
+```
+
+## Building the Code
+
+### Prerequisites
+
+Ensure you have following components:
+
+- [Git](https://git-scm.com/)
+- a .NET IDE of your choice, preferably [Visual Studio 2022](https://visualstudio.microsoft.com/vs/)
+- the .NET SDK
+
+### Git
+
+Clone the repository:
+
+```git
+git clone https://github.com/itsWindows11/ThreadSharp
+```
+
+### Build the project
+
+- Open `ThreadSharp.sln`.
+- Set the Startup Project to `ThreadSharp.csproj` (of course!)
+- Build with `DEBUG` mode activated
+
+## License
+
+Copyright (c) 2024 `itsWindows11` & `ThreadSharp` contributors.
+
+Licensed under the MIT license as stated in the [LICENSE](https://github.com/itsWindows11/ThreadSharp/blob/main/LICENSE).

--- a/src/README.md
+++ b/src/README.md
@@ -40,4 +40,4 @@ git clone https://github.com/itsWindows11/ThreadSharp
 
 Copyright (c) 2024 `itsWindows11` & `ThreadSharp` contributors.
 
-Licensed under the MIT license as stated in the [LICENSE](https://github.com/itsWindows11/ThreadSharp/blob/main/LICENSE).
+Licensed under the [MIT License](https://github.com/itsWindows11/ThreadSharp/blob/main/LICENSE).

--- a/src/ThreadSharp/ThreadSharp.csproj
+++ b/src/ThreadSharp/ThreadSharp.csproj
@@ -40,7 +40,7 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-    <None Include="..\..\README.md">
+    <None Include="..\README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cbe2ac0f-b0bc-409f-8d2e-9f71d500088a)

As anyone can tell, NuGet _hates_ inline HTML. So, I created a NuGet specific README that's more simplified and doesn't contain anything particularly special.

I also rewrote the existing README to make it look prettier. Enjoy!